### PR TITLE
Add machine-readable guards on sensitive RE skills

### DIFF
--- a/.claude/skills/re-cracking/SKILL.md
+++ b/.claude/skills/re-cracking/SKILL.md
@@ -6,6 +6,7 @@ description: >
   子技能：[[re-license]] [[re-patching]] [[re-keygen]] [[re-drm]]。
   触发词：破解、crack、注册码、序列号、授权验证、绕过验证、打补丁、patch、keygen、注册机、授权绕过。
 capabilities: [license-analysis]
+guard: {"require_authorization": true, "forbidden": ["unauthorized_cracking", "commercial_bypass", "keygen_distribution"]}
 ---
 
 # 软件破解（授权定位 / 补丁 / 注册机）

--- a/.claude/skills/re-exploit/SKILL.md
+++ b/.claude/skills/re-exploit/SKILL.md
@@ -3,6 +3,7 @@ name: re-exploit
 description: >
   利用开发：ROP 链构造、堆利用。
   触发词：ROP、堆利用、fastbin、tcache、利用开发、exploit
+guard: {"require_authorization": true, "forbidden": ["unauthorized_exploitation", "weaponization_against_third_party"]}
 ---
 
 # 利用开发（ROP 链构造 / 堆利用）

--- a/.claude/skills/re-keygen/SKILL.md
+++ b/.claude/skills/re-keygen/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: re-keygen
 description: 注册机算法还原。触发词：注册机、keygen、算法还原、序列号生成
+guard: {"require_authorization": true, "forbidden": ["unauthorized_cracking", "commercial_bypass", "keygen_distribution"]}
 ---
 
 # 注册机算法还原（keygen）


### PR DESCRIPTION
## Summary
- `re-ai-attack` already declares `guard: {"require_authorization": true, ...}`.
- The skill template treats cracking / keygen / exploit work as sensitive, but `re-cracking`, `re-keygen`, and `re-exploit` had no machine-readable guard.
- This adds the same `require_authorization` contract so hosts can enforce the existing policy.

## Test plan
- [x] `git apply` of the three one-line frontmatter additions on `bc7fac97`
- [x] `node validate.mjs` still reports `OK: 121 skills validated` after the overlay apply in the pin workspace